### PR TITLE
Modularize tool command generation

### DIFF
--- a/http_request_tool_converter.py
+++ b/http_request_tool_converter.py
@@ -1,6 +1,7 @@
 import sys
 import argparse
-from urllib.parse import urlparse
+
+from tool_builders import registry
 
 def parse_request(file_path):
     with open(file_path, 'r') as f:
@@ -29,53 +30,17 @@ def build_url(headers, path):
     scheme = "https" if headers.get("X-Forwarded-Proto", "").lower() == "https" else "http"
     return f"{scheme}://{host}{path}"
 
-def build_wfuzz_command(method, url, headers, body):
-    cmd = f"wfuzz -c -w /usr/share/seclists/Fuzzing/special-chars.txt -u \"{url}\""
-    if method.upper() != "GET":
-        cmd += f" -X {method.upper()}"
-    if body:
-        cmd += f" -d \"{body}\""
-    for k, v in headers.items():
-        if k.lower() != "host":
-            cmd += f" -H \"{k}: {v}\""
-    return cmd
-
-def build_sqlmap_command(method, url, headers, body):
-    cmd = f"sqlmap -u \"{url}\""
-
-    if method.upper() != "GET":
-        cmd += f" --method={method.upper()}"
-
-    if body:
-        cmd += f" --data=\"{body}\""
-
-    if 'User-Agent' in headers:
-        cmd += f" -A \"{headers['User-Agent']}\""
-    if 'Cookie' in headers:
-        cmd += f" --cookie=\"{headers['Cookie']}\""
-    if 'Referer' in headers:
-        cmd += f" --referer=\"{headers['Referer']}\""
-    if 'Host' in headers:
-        cmd += f" --host=\"{headers['Host']}\""
-
-    extra_headers = []
-    for k, v in headers.items():
-        if k not in ['User-Agent', 'Cookie', 'Referer', 'Host']:
-            extra_headers.append(f"{k}: {v}")
-    if extra_headers:
-        header_str = "\\n".join(extra_headers)
-        cmd += f" --headers=\"{header_str}\""
-
-    cmd += " --level=5 --risk=3"
-    return cmd
-
 def main():
     parser = argparse.ArgumentParser(
         description="Convert HTTP request files into command-line tool templates."
     )
     parser.add_argument("request_file", help="Path to HTTP request file")
-    parser.add_argument("--tool", required=True, choices=["wfuzz", "sqlmap"],
-                        help="Target tool to generate command for")
+    parser.add_argument(
+        "--tool",
+        required=True,
+        choices=registry.choices(),
+        help="Target tool to generate command for",
+    )
 
     args = parser.parse_args()
 
@@ -85,14 +50,11 @@ def main():
 
         print("🔎 Note: This tool assumes http unless 'X-Forwarded-Proto: https' is set.\n")
 
-        if args.tool == "wfuzz":
-            print("===== wfuzz コマンド =====")
-            print(build_wfuzz_command(method, url, headers, body))
-            print("👉 Replace value with 'FUZZ' to test injection points.")
-        elif args.tool == "sqlmap":
-            print("===== sqlmap コマンド =====")
-            print(build_sqlmap_command(method, url, headers, body))
-            print("👉 Insert '*' at desired injection point (e.g., TrackingId=abc*).")
+        template = registry.build(args.tool, method, url, headers, body)
+        print(template.title)
+        print(template.command)
+        if template.tip:
+            print(template.tip)
 
     except Exception as e:
         print(f"[!] Error: {e}")

--- a/tool_builders/__init__.py
+++ b/tool_builders/__init__.py
@@ -1,0 +1,50 @@
+"""Tool builders for converting HTTP requests into tool-specific commands."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+
+@dataclass(frozen=True)
+class ToolTemplate:
+    """Represents printable information for a tool command."""
+
+    title: str
+    command: str
+    tip: str | None = None
+
+
+Builder = Callable[[str, str, dict[str, str], str], ToolTemplate]
+
+
+class ToolRegistry:
+    """Registry that keeps the mapping of tool names to builder callables."""
+
+    def __init__(self) -> None:
+        self._builders: Dict[str, Builder] = {}
+
+    def register(self, name: str, builder: Builder) -> None:
+        if name in self._builders:
+            raise ValueError(f"Tool '{name}' is already registered")
+        self._builders[name] = builder
+
+    def build(self, name: str, method: str, url: str, headers: dict[str, str], body: str) -> ToolTemplate:
+        try:
+            builder = self._builders[name]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported tool: {name}") from exc
+        return builder(method, url, headers, body)
+
+    def choices(self) -> list[str]:
+        return sorted(self._builders)
+
+
+registry = ToolRegistry()
+
+
+# Ensure default tool builders are registered on import.
+from . import wfuzz as _wfuzz  # noqa: F401
+from . import sqlmap as _sqlmap  # noqa: F401
+
+
+__all__ = ["ToolTemplate", "registry"]

--- a/tool_builders/sqlmap.py
+++ b/tool_builders/sqlmap.py
@@ -1,0 +1,42 @@
+"""sqlmap tool builder."""
+from __future__ import annotations
+
+from . import ToolTemplate, registry
+
+
+def build(method: str, url: str, headers: dict[str, str], body: str) -> ToolTemplate:
+    cmd = f"sqlmap -u \"{url}\""
+
+    if method.upper() != "GET":
+        cmd += f" --method={method.upper()}"
+
+    if body:
+        cmd += f" --data=\"{body}\""
+
+    if "User-Agent" in headers:
+        cmd += f" -A \"{headers['User-Agent']}\""
+    if "Cookie" in headers:
+        cmd += f" --cookie=\"{headers['Cookie']}\""
+    if "Referer" in headers:
+        cmd += f" --referer=\"{headers['Referer']}\""
+    if "Host" in headers:
+        cmd += f" --host=\"{headers['Host']}\""
+
+    extra_headers = []
+    for k, v in headers.items():
+        if k not in ["User-Agent", "Cookie", "Referer", "Host"]:
+            extra_headers.append(f"{k}: {v}")
+    if extra_headers:
+        header_str = "\\n".join(extra_headers)
+        cmd += f" --headers=\"{header_str}\""
+
+    cmd += " --level=5 --risk=3"
+
+    return ToolTemplate(
+        title="===== sqlmap コマンド =====",
+        command=cmd,
+        tip="👉 Insert '*' at desired injection point (e.g., TrackingId=abc*).",
+    )
+
+
+registry.register("sqlmap", build)

--- a/tool_builders/wfuzz.py
+++ b/tool_builders/wfuzz.py
@@ -1,0 +1,24 @@
+"""wfuzz tool builder."""
+from __future__ import annotations
+
+from . import ToolTemplate, registry
+
+
+def build(method: str, url: str, headers: dict[str, str], body: str) -> ToolTemplate:
+    cmd = f"wfuzz -c -w /usr/share/seclists/Fuzzing/special-chars.txt -u \"{url}\""
+    if method.upper() != "GET":
+        cmd += f" -X {method.upper()}"
+    if body:
+        cmd += f" -d \"{body}\""
+    for k, v in headers.items():
+        if k.lower() != "host":
+            cmd += f" -H \"{k}: {v}\""
+
+    return ToolTemplate(
+        title="===== wfuzz コマンド =====",
+        command=cmd,
+        tip="👉 Replace value with 'FUZZ' to test injection points.",
+    )
+
+
+registry.register("wfuzz", build)


### PR DESCRIPTION
## Summary
- introduce a registry-driven module structure so each tool builder registers itself
- refactor the main CLI to consume the registry and print tool output without conditional branching

## Testing
- python http_request_tool_converter.py sample_request.txt --tool wfuzz
- python http_request_tool_converter.py sample_request.txt --tool sqlmap

------
https://chatgpt.com/codex/tasks/task_e_68d8c90648cc832f911bdb3ee9f88e89