### PR TITLE
Add ffuf and curl builders for HTTP request converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - HTTP リクエストファイルを解析し、メソッド・パス・ヘッダー・ボディを抽出
 - `X-Forwarded-Proto` ヘッダーの有無からスキーム (http/https) を自動判定
 - wfuzz 向けの `-X` や `-H` オプションを自動組み立て
+- ffuf 向けに `-w` `-H` `-d` などのテンプレートを生成
+- curl 向けに `-X` や `-H`, `--data-raw` を組み合わせたリクエスト例を出力
 - sqlmap 向けにメソッド指定、リクエストボディ、主要ヘッダー (`User-Agent`, `Cookie`, `Referer`, `Host`) などを適切に配置
 - 追加ヘッダーも `--headers` オプションでまとめて反映
 - 生成後の調整ポイント（FUZZ や `*` の挿入箇所）をメッセージで案内
@@ -47,6 +49,12 @@ python3 --version  # Python 3.8 以上であることを確認
 ```bash
 # 例: wfuzz 形式に変換
 python3 http_request_tool_converter.py --tool wfuzz request.txt
+
+# 例: ffuf 形式に変換
+python3 http_request_tool_converter.py --tool ffuf request.txt
+
+# 例: curl コマンドに変換
+python3 http_request_tool_converter.py --tool curl request.txt
 
 # 例: sqlmap 形式に変換
 python3 http_request_tool_converter.py --tool sqlmap request.txt

--- a/tool_builders/__init__.py
+++ b/tool_builders/__init__.py
@@ -43,8 +43,10 @@ registry = ToolRegistry()
 
 
 # Ensure default tool builders are registered on import.
-from . import wfuzz as _wfuzz  # noqa: F401
+from . import curl as _curl  # noqa: F401
+from . import ffuf as _ffuf  # noqa: F401
 from . import sqlmap as _sqlmap  # noqa: F401
+from . import wfuzz as _wfuzz  # noqa: F401
 
 
 __all__ = ["ToolTemplate", "registry"]

--- a/tool_builders/curl.py
+++ b/tool_builders/curl.py
@@ -1,0 +1,23 @@
+"""curl tool builder."""
+from __future__ import annotations
+
+from . import ToolTemplate, registry
+
+
+def build(method: str, url: str, headers: dict[str, str], body: str) -> ToolTemplate:
+    cmd = f"curl -i -s -k -X {method.upper()} \"{url}\""
+
+    for key, value in headers.items():
+        cmd += f" -H \"{key}: {value}\""
+
+    if body:
+        cmd += f" --data-raw \"{body}\""
+
+    return ToolTemplate(
+        title="===== curl コマンド =====",
+        command=cmd,
+        tip="👉 Consider --data-binary for non-form payloads or remove -X for simple GET requests.",
+    )
+
+
+registry.register("curl", build)

--- a/tool_builders/ffuf.py
+++ b/tool_builders/ffuf.py
@@ -1,0 +1,27 @@
+"""ffuf tool builder."""
+from __future__ import annotations
+
+from . import ToolTemplate, registry
+
+
+def build(method: str, url: str, headers: dict[str, str], body: str) -> ToolTemplate:
+    cmd = f"ffuf -u \"{url}\" -w /path/to/wordlist.txt"
+
+    if method.upper() != "GET":
+        cmd += f" -X {method.upper()}"
+
+    if body:
+        cmd += f" -d \"{body}\""
+
+    for key, value in headers.items():
+        if key.lower() != "host":
+            cmd += f" -H \"{key}: {value}\""
+
+    return ToolTemplate(
+        title="===== ffuf コマンド =====",
+        command=cmd,
+        tip="👉 Replace the target parameter with 'FUZZ' and adjust the wordlist path.",
+    )
+
+
+registry.register("ffuf", build)


### PR DESCRIPTION
## Summary
- add ffuf and curl tool builders that emit templated commands from parsed requests
- register the new builders so they are available through the CLI registry
- document the new tool options in the README usage examples and feature list

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d948610f78832f9fc65de29b376969